### PR TITLE
un-flag content as new when it is not new.

### DIFF
--- a/src/AppBundle/Resources/views/Default/rulesreference.en.html.twig
+++ b/src/AppBundle/Resources/views/Default/rulesreference.en.html.twig
@@ -178,17 +178,15 @@
 
     <p><strong>Related:</strong> <a href="#Printed">Printed</a>, <a href="#Modifiers">Modifiers</a></p>
 
-    <span class="new">
-<h3 id="Bestow">Bestow</h3>
+    <h3 id="Bestow">Bestow</h3>
 
-<p>Bestow is a keyword ability. When a card with bestow (X) enters play, the card's controller may move up to X gold from his or her gold pool to that card. This decision is made immediately upon the card entering play, after resolving any interrupts to the card entering play but prior to triggering any reactions (forced or otherwise) to the card entering play.</p>
+    <p>Bestow is a keyword ability. When a card with bestow (X) enters play, the card's controller may move up to X gold from his or her gold pool to that card. This decision is made immediately upon the card entering play, after resolving any interrupts to the card entering play but prior to triggering any reactions (forced or otherwise) to the card entering play.</p>
 
-<ul>
-<li>  When placing gold using bestow, a player may choose any amount of gold, up to the (X) value of the card with bestow. <em>(For example, when a card with "bestow (2)" enters play, its controller may move 0, 1, or 2 gold from his or her gold pool to that card.)</em></li>
-<li>  Gold on a card is not in its controller's gold pool. Game steps and abilities that use or interact with gold in a player's gold pool do not interact with gold on cards.</li>
-<li>  When gold is discarded from a card with bestow, it is returned to the treasury.</li>
-</ul>
-</span>
+    <ul>
+        <li>  When placing gold using bestow, a player may choose any amount of gold, up to the (X) value of the card with bestow. <em>(For example, when a card with "bestow (2)" enters play, its controller may move 0, 1, or 2 gold from his or her gold pool to that card.)</em></li>
+        <li>  Gold on a card is not in its controller's gold pool. Game steps and abilities that use or interact with gold in a player's gold pool do not interact with gold on cards.</li>
+        <li>  When gold is discarded from a card with bestow, it is returned to the treasury.</li>
+    </ul>
 
     <h3 id="Blank">Blank</h3>
 
@@ -1765,71 +1763,69 @@
 
     <p><strong>Related:</strong> <a href="#Duplicates">Duplicates</a>, <a href="#Mulligan">Mulligan</a></p>
 
-    <span class="new">
-<h3 id="Shadows">Shadows</h3>
+    <h3 id="Shadows">Shadows</h3>
 
-<p>Shadows is a new feature of <em>A Game of Thrones: The Card Game</em>, introducing a new keyword ability and a new game area.</p>
+    <p>Shadows is a new feature of <em>A Game of Thrones: The Card Game</em>, introducing a new keyword ability and a new game area.</p>
 
-<h4>The Shadow Keyword</h4>
+    <h4>The Shadow Keyword</h4>
 
-<p>Shadow is a keyword ability. A card with shadow (X) can be marshaled facedown into its controller's shadows area for 2 gold. That card can later be played (if it is an event) or brought into play faceup (if it is a character, location, or attachment) by paying X gold.</p>
+    <p>Shadow is a keyword ability. A card with shadow (X) can be marshaled facedown into its controller's shadows area for 2 gold. That card can later be played (if it is an event) or brought into play faceup (if it is a character, location, or attachment) by paying X gold.</p>
 
-<p>In addition to the presence of the shadow keyword in the text box, cards with the shadow keyword can be easily identified by the presence of a banner around the card's gold cost.</p>
+    <p>In addition to the presence of the shadow keyword in the text box, cards with the shadow keyword can be easily identified by the presence of a banner around the card's gold cost.</p>
 
-<h4>Marshaling a card into shadows</h4>
+    <h4>Marshaling a card into shadows</h4>
 
-<p>During the marshaling phase, the active player may, as a player action, pay 2 gold to marshal a card with the shadow keyword into shadows from his or her hand. A card marshaled into shadows is placed facedown in an area clearly separate from other game areas. There is no limit to the number of cards that a player can marshal into shadows during the marshaling phase.</p>
+    <p>During the marshaling phase, the active player may, as a player action, pay 2 gold to marshal a card with the shadow keyword into shadows from his or her hand. A card marshaled into shadows is placed facedown in an area clearly separate from other game areas. There is no limit to the number of cards that a player can marshal into shadows during the marshaling phase.</p>
 
-<p>Marshaling a card into shadows is not considered to be "playing" a card. Marshaling a card into shadows is not considered to be marshaling a card with any of that card's characteristics; it is only considered to be "marshaling a card into shadows."</p>
+    <p>Marshaling a card into shadows is not considered to be "playing" a card. Marshaling a card into shadows is not considered to be marshaling a card with any of that card's characteristics; it is only considered to be "marshaling a card into shadows."</p>
 
-<p>Cards without the shadow keyword cannot be marshaled into shadows. However, such cards may be placed into shadows by card effects. If a card is placed into shadows by a card effect, that card is placed facedown in its controller's shadows area. An effect that causes a card to "return" to shadows will place that card into shadows, even if that card did not enter play from shadows.</p>
+    <p>Cards without the shadow keyword cannot be marshaled into shadows. However, such cards may be placed into shadows by card effects. If a card is placed into shadows by a card effect, that card is placed facedown in its controller's shadows area. An effect that causes a card to "return" to shadows will place that card into shadows, even if that card did not enter play from shadows.</p>
 
-<p>During setup, cards with the shadow keyword (including events) may be placed into shadows by spending 2 gold from the amount allocated for setup for each card. When setup cards are revealed, any cards that were placed into shadows remain facedown in their controller's shadows area.</p>
+    <p>During setup, cards with the shadow keyword (including events) may be placed into shadows by spending 2 gold from the amount allocated for setup for each card. When setup cards are revealed, any cards that were placed into shadows remain facedown in their controller's shadows area.</p>
 
-<h4>While a card is in shadows</h4>
+    <h4>While a card is in shadows</h4>
 
-<p>Shadows is a distinct out-of-play area; cards in shadows are not considered to be "in play" nor "in hand."</p>
+    <p>Shadows is a distinct out-of-play area; cards in shadows are not considered to be "in play" nor "in hand."</p>
 
-<p>Each card in shadows is facedown, and remains facedown while it is in shadows. A player may look at any card he or she controls in shadows, at any time. A player may not look at any opponent's card in shadows.</p>
+    <p>Each card in shadows is facedown, and remains facedown while it is in shadows. A player may look at any card he or she controls in shadows, at any time. A player may not look at any opponent's card in shadows.</p>
 
-<p>If a player has multiple cards in shadows, that player must ensure that those cards can be easily differentiated from one another. A player cannot shuffle or rearrange his or her cards in shadows in a way that disguises the identity of those cards.</p>
+    <p>If a player has multiple cards in shadows, that player must ensure that those cards can be easily differentiated from one another. A player cannot shuffle or rearrange his or her cards in shadows in a way that disguises the identity of those cards.</p>
 
-<p>Each player's shadows area should be visually separate from their other game areas, and from each other player's.</p>
+    <p>Each player's shadows area should be visually separate from their other game areas, and from each other player's.</p>
 
-<p>Some effects may place one or more tokens on a card in shadows. If a card transitions from shadows to any other game area, all tokens on that card are discarded.</p>
+    <p>Some effects may place one or more tokens on a card in shadows. If a card transitions from shadows to any other game area, all tokens on that card are discarded.</p>
 
-<h4>Bringing a card out of shadows</h4>
+    <h4>Bringing a card out of shadows</h4>
 
-<p>A card's "shadow cost" is the value listed in parentheses after the shadow keyword. For instance, a card with the text "Shadow (4)" has a shadow cost of 4. Any effect that modifies the cost to bring a card out of shadows modifies that card's shadow cost.</p>
+    <p>A card's "shadow cost" is the value listed in parentheses after the shadow keyword. For instance, a card with the text "Shadow (4)" has a shadow cost of 4. Any effect that modifies the cost to bring a card out of shadows modifies that card's shadow cost.</p>
 
-<p>As an action, a player may bring a character, location, or attachment out of shadows and into play by paying its shadow cost (e.g. paying 4 gold to bring a "Shadow (4)" card into play). A card that is brought out of shadows and into play is considered to be entering play using a card ability; it is not considered to have been "marshaled" or "played."</p>
+    <p>As an action, a player may bring a character, location, or attachment out of shadows and into play by paying its shadow cost (e.g. paying 4 gold to bring a "Shadow (4)" card into play). A card that is brought out of shadows and into play is considered to be entering play using a card ability; it is not considered to have been "marshaled" or "played."</p>
 
-<p>An attachment that is brought out of shadows must immediately be attached to an eligible card. If there are no eligible cards to attach to, the attachment is discarded without entering play.</p>
+    <p>An attachment that is brought out of shadows must immediately be attached to an eligible card. If there are no eligible cards to attach to, the attachment is discarded without entering play.</p>
 
-<p>An event in shadows may be played by paying its shadow cost whenever its triggering condition and/or play conditions are met, as if a player were playing it from his or her hand.</p>
+    <p>An event in shadows may be played by paying its shadow cost whenever its triggering condition and/or play conditions are met, as if a player were playing it from his or her hand.</p>
 
-<p>If a card has multiple instances of the shadow keyword, each with a different (X) value, the player controlling the card may choose which instance of the shadow keyword is used to bring the card out of shadows.</p>
+    <p>If a card has multiple instances of the shadow keyword, each with a different (X) value, the player controlling the card may choose which instance of the shadow keyword is used to bring the card out of shadows.</p>
 
-<p>Some effects allow a card to be "put into play" from shadows. Such abilities place the card directly into play from its controller's shadows area. The shadow cost of a card being "put into play" is not paid. An event card cannot be put into play by such an effect.</p>
+    <p>Some effects allow a card to be "put into play" from shadows. Such abilities place the card directly into play from its controller's shadows area. The shadow cost of a card being "put into play" is not paid. An event card cannot be put into play by such an effect.</p>
 
-<p>A character, location, or attachment is considered to "come out of shadows" if it enters play from shadows. An event is considered to "come out of shadows" if it is played from shadows.</p>
+    <p>A character, location, or attachment is considered to "come out of shadows" if it enters play from shadows. An event is considered to "come out of shadows" if it is played from shadows.</p>
 
-<h4>Printed cost of shadows cards</h4>
+    <h4>Printed cost of shadows cards</h4>
 
-<p>Many cards with the shadow keyword also have a standard printed cost, in the upper left corner of the card. Any reference to a card's "printed cost" refers to this value. Such a card may be marshaled or played from a player's hand by paying its printed cost, following standard game rules.</p>
+    <p>Many cards with the shadow keyword also have a standard printed cost, in the upper left corner of the card. Any reference to a card's "printed cost" refers to this value. Such a card may be marshaled or played from a player's hand by paying its printed cost, following standard game rules.</p>
 
-<p>During setup, such a card may either be placed as normal for its printed cost, or placed into shadows for 2 gold. While such a card is in shadows, it may be brought out of shadows only by paying its shadow cost.</p>
+    <p>During setup, such a card may either be placed as normal for its printed cost, or placed into shadows for 2 gold. While such a card is in shadows, it may be brought out of shadows only by paying its shadow cost.</p>
 
-<p>Some cards with the shadow keyword have a "-" in place of their printed cost. Such a card cannot be marshaled or played from a player's hand, and may only be played by being brought out of shadows. Such a card has no printed cost. If an ability references the printed cost of that card, a null value is returned.</p>
+    <p>Some cards with the shadow keyword have a "-" in place of their printed cost. Such a card cannot be marshaled or played from a player's hand, and may only be played by being brought out of shadows. Such a card has no printed cost. If an ability references the printed cost of that card, a null value is returned.</p>
 
-<h4>Unique cards and shadows</h4>
+    <h4>Unique cards and shadows</h4>
 
-<p>A unique card may be marshaled into shadows even if its owner already has a copy of that card in play or in his or her dead pile.</p>
+    <p>A unique card may be marshaled into shadows even if its owner already has a copy of that card in play or in his or her dead pile.</p>
 
-<p>A player may bring a unique card out of shadows by paying its shadow cost even if he or she owns and controls another copy of that unique card in play. However, the card will enter play as a duplicate.</p>
+    <p>A player may bring a unique card out of shadows by paying its shadow cost even if he or she owns and controls another copy of that unique card in play. However, the card will enter play as a duplicate.</p>
 
 <p>Bringing a unique card out of shadows is subject to the same restrictions as any other attempt to put a unique card into play. If a unique card is unable to enter play legally, it may not be brought out of shadows.</p>
-</span>
 
     <h3 id="Stand">Stand, Standing</h3>
 
@@ -1900,11 +1896,11 @@
             valid targets), then the ability cannot be initiated. This initiation check is made at the same time the
             ability's play restrictions are checked.
         </li>
-        <span class="new">
-<li>  <s>At the time targets are chosen, any currently valid targets are eligible to be chosen. (This choice is not restricted only to targets that were present during the initiation check.)</s> Overruled by <a
+        <li>
+            <s>At the time targets are chosen, any currently valid targets are eligible to be chosen. (This choice is not restricted only to targets that were present during the initiation check.)</s> Overruled by <a
             href="http://thronesdb.com/faq#Player_Choices_While_Initiating_Abilities"
-            target="_blank">FAQ (3.2)</a>.</li>
-</span>
+            target="_blank">FAQ (3.2)</a>.
+        </li>
         <li> If multiple targets are required to be chosen by the same player, these are chosen simultaneously.</li>
         <li> An effect that can choose "any number" of targets does not successfully resolve (and cannot change the game
             state) if zero of those targets are chosen.


### PR DESCRIPTION
some sections in the rules reference are styled as red-colored text, indicating that their contents is _new_. that's not the case anymore, so let's get rid of the red.