### PR TITLE
Read only decklist social stats

### DIFF
--- a/src/AppBundle/Resources/views/Decklist/decklist.html.twig
+++ b/src/AppBundle/Resources/views/Decklist/decklist.html.twig
@@ -43,7 +43,28 @@
                     <div class="pull-right">
                         <span class="hidden-xs">{{ 'decklist.view.published' | trans }}: </span>
                         <time datetime="{{ decklist.dateCreation|date('c') }}">{{ decklist.dateCreation|date('M d, Y') }}</time>
-                        {{ macros.decklist_social_icons(decklist) }}
+                        {% if is_granted('IS_AUTHENTICATED_REMEMBERED') %}
+                            <span class="social-icons">
+                                <a id="social-icon-like" href="#" class="social-icon-like" data-toggle="tooltip" data-placement="bottom"
+                                   title="{{ 'decklist.view.social.like' | trans }}">
+                                    <span class="fas fa-heart"></span> <span class="num">{{ decklist.nbVotes }}</span>
+                                </a>
+                                <a id="social-icon-favorite" href="#" class="social-icon-favorite" data-toggle="tooltip" data-placement="bottom"
+                                   title="{{ 'decklist.view.social.favorite' | trans }}">
+                                    <span class="fas fa-star"></span> <span class="num">{{ decklist.nbFavorites }}</span>
+                                </a>
+                                <a id="social-icon-comment" href="#comment-form" class="social-icon-comment" data-toggle="tooltip"
+                                   data-placement="bottom" title="{{ 'decklist.view.social.comment' | trans }}">
+                                    <span class="fas fa-comment"></span> <span class="num">{{ decklist.nbComments }}</span>
+                                </a>
+                                <span class="social-icon-version" data-toggle="tooltip" data-placement="bottom"
+                                      title="{{ 'decklist.view.social.version' | trans }}">
+                                    <span class="fas fa-code-branch"></span> <span class="num">{{ decklist.version }}</span>
+                                </span>
+                            </span>
+                        {% else %}
+                            {{ macros.decklist_social_icons(decklist) }}
+                        {% endif %}
                     </div>
                     {% if duplicate %}
                         {% set duplink %}

--- a/src/AppBundle/Resources/views/macros.html.twig
+++ b/src/AppBundle/Resources/views/macros.html.twig
@@ -43,23 +43,23 @@
 {% endmacro %}
 
 {% macro decklist_social_icons(decklist) %}
-<span class="social-icons">
-    <a id="social-icon-like" href="#" class="social-icon-like" data-toggle="tooltip" data-placement="bottom"
-        title="{{ 'decklist.view.social.like' | trans }}">
+    <span class="social-icons">
+    <span class="social-icon-like" data-toggle="tooltip" data-placement="bottom"
+          title="{{ 'decklist.view.social.like' | trans }}">
         <span class="fas fa-heart"></span> <span class="num">{{ decklist.nbVotes }}</span>
-    </a>
-    <a id="social-icon-favorite" href="#" class="social-icon-favorite" data-toggle="tooltip" data-placement="bottom"
-        title="{{ 'decklist.view.social.favorite' | trans }}">
+    </span>
+    <span class="social-icon-favorite" data-toggle="tooltip" data-placement="bottom"
+          title="{{ 'decklist.view.social.favorite' | trans }}">
         <span class="fas fa-star"></span> <span class="num">{{ decklist.nbFavorites }}</span>
-    </a>
-    <a id="social-icon-comment" href="#comment-form" class="social-icon-comment" data-toggle="tooltip"
-        data-placement="bottom" title="{{ 'decklist.view.social.comment' | trans }}">
+    </span>
+    <span class="social-icon-comment" data-toggle="tooltip"
+          data-placement="bottom" title="{{ 'decklist.view.social.comment' | trans }}">
         <span class="fas fa-comment"></span> <span class="num">{{ decklist.nbComments }}</span>
-    </a>
-    <a class="social-icon-version" data-toggle="tooltip" data-placement="bottom"
-        title="{{ 'decklist.view.social.version' | trans }}">
+    </span>
+    <span class="social-icon-version" data-toggle="tooltip" data-placement="bottom"
+          title="{{ 'decklist.view.social.version' | trans }}">
         <span class="fas fa-code-branch"></span> <span class="num">{{ decklist.version }}</span>
-    </a>
+    </span>
 </span>
 {% endmacro %}
 


### PR DESCRIPTION
by default, the decklist social stats (total number of likes, stars and comments) are now read-only.

the _only_ place where these can be interacted with (liking, starring, and commenting) is on the decklist details page, and _only_ if the current user is logged in.

fixes #351 
fixes #352 
fixes #361 