### PR TITLE
Remove unused/undefined footer

### DIFF
--- a/src/AppBundle/Resources/views/Export/default.txt.twig
+++ b/src/AppBundle/Resources/views/Export/default.txt.twig
@@ -48,5 +48,3 @@ Event{% if events|length > 1 %}s{% endif %}
 {% for slot in events %}
 {{ slot.quantity }}x {{ slot.card.name }} ({{ slot.card.pack.name }})
 {% endfor %}
-
-{{ footer|default('') }}


### PR DESCRIPTION
`footer` is not set to any twig include (neither in `BuilderController` nor `SocialController`)