### PR TITLE
Remove unused/undefined footer

### DIFF
--- a/src/AppBundle/Resources/views/Export/sortedbycycle.txt.twig
+++ b/src/AppBundle/Resources/views/Export/sortedbycycle.txt.twig
@@ -21,5 +21,3 @@ From {{ first_pack.pack.name }}{% if first_pack.nb > 1 %} ({{ first_pack.nb }}){
 {{ slot.quantity }}x {{ slot.card.name }} ({{ slot.card.pack.name }} #{{ slot.card.position }})
 {% endfor %}
 {% endfor %}
-
-{{ footer|default('') }}


### PR DESCRIPTION
`footer` is not set to any twig include (neither in `BuilderController` nor `SocialController`)