### PR TITLE
fixes regression in routing by refining decklist_lists route.

### DIFF
--- a/src/Controller/SocialController.php
+++ b/src/Controller/SocialController.php
@@ -560,9 +560,11 @@ class SocialController extends Controller
      *     name="decklists_list",
      *     methods={"GET"},
      *     defaults={"type"="popular", "page"=1},
-     *     requirements={"page"="\d+"}
+     *     requirements={
+     *         "type"="find|favorites|mine|recent|hottopics|tournament|popular",
+     *         "page"="\d+"
+     *     }
      * )
-     *
      * @param Request $request
      * @param string $type
      * @param int $page


### PR DESCRIPTION


the decklists_searchform route had become inaccessible due to a naming
conflict with the decklists_list route. refining the values allowed for
the "type" component in the route fixes this.