### PR TITLE
Expand Pods to work without restricted card

### DIFF
--- a/src/Services/RestrictionsChecker.php
+++ b/src/Services/RestrictionsChecker.php
@@ -124,9 +124,7 @@ class RestrictionsChecker
 
 
         foreach ($pods as $pod) {
-            // @todo clean this up once it's clear whether 'restricted' becomes optional or nullable [ST 2020/12/27]
-            // @link https://github.com/throneteki/throneteki-json-data/issues/95
-            if (array_key_exists('restricted', $pod) || ! empty($pod['restricted'])) {
+            if (array_key_exists('restricted', $pod)) {
                 // if a pod has a restricted card, then the deck cannot include cards
                 // from pods if the restricted-pod's restricted card is part of the deck.
                 $restricted = $pod['restricted'];

--- a/src/Services/RestrictionsChecker.php
+++ b/src/Services/RestrictionsChecker.php
@@ -122,19 +122,30 @@ class RestrictionsChecker
             return true;
         }
 
-        // a deck cannot include cards from pods if the pod's restricted card is part of the deck.
-        $isRestrictedInPod = false;
+
         foreach ($pods as $pod) {
-            $restricted = $pod['restricted'];
-            if (! in_array($restricted, $cardsInDeck)) {
-                continue;
-            }
-            if (array_intersect($pod['cards'], $cardsInDeck)) {
-                $isRestrictedInPod = true;
-                break;
+            // @todo clean this up once it's clear whether 'restricted' becomes optional or nullable [ST 2020/12/27]
+            // @link https://github.com/throneteki/throneteki-json-data/issues/95
+            if (array_key_exists('restricted', $pod) || ! empty($pod['restricted'])) {
+                // if a pod has a restricted card, then the deck cannot include cards
+                // from pods if the restricted-pod's restricted card is part of the deck.
+                $restricted = $pod['restricted'];
+                if (! in_array($restricted, $cardsInDeck)) {
+                    continue;
+                }
+                if (array_intersect($pod['cards'], $cardsInDeck)) {
+                    return true;
+                }
+            } else {
+                // a deck cannot include more than one card from each pod.
+                $podCardsInDeck = array_intersect($pod['cards'], $cardsInDeck);
+                if (1 < count($podCardsInDeck)) {
+                    return true;
+                }
             }
         }
-        return $isRestrictedInPod;
+
+        return false;
     }
 
     /**

--- a/templates/Restrictions/poddescription.html.twig
+++ b/templates/Restrictions/poddescription.html.twig
@@ -5,5 +5,7 @@
 <p>Some cards interactions are so powerful that the inclusion of these cards in a deck comes with
     additional restrictions. Those cards are grouped together in pods.</p>
 <p>No more than one card from each pod may be included in a deck.</p>
-<p>However, if a pod contains a card from the restricted list (indicated in <strong>bold text</strong> if applicable),
-    then no cards from that pod other than this restricted card may be included in a deck.</p>
+<p>However, if a pod contains a card from the restricted list (indicated in <strong>bold text</strong> if applicable)
+    and you choose that card as your restricted card, then the other cards from that pod cannot
+    be included in your deck. If you choose a different restricted card, you may include any number of
+    unrestricted cards from that pod in your deck.</p>

--- a/templates/Restrictions/poddescription.html.twig
+++ b/templates/Restrictions/poddescription.html.twig
@@ -2,8 +2,8 @@
     @file
     Partial template for rendering a description for pods.
 #}
-<p>Some restricted cards are so powerful that their inclusion in a deck comes with
-    additional deckbuilding restrictions.
-    If a player selects one of these cards as their restricted card
-    (shown in <strong>bold text</strong> below), they may not include any of the
-    cards listed following them.</p>
+<p>Some cards interactions are so powerful that the inclusion of these cards in a deck comes with
+    additional restrictions. Those cards are grouped together in pods.</p>
+<p>No more than one card from each pod may be included in a deck.</p>
+<p>However, if a pod contains a card from the restricted list (indicated in <strong>bold text</strong> if applicable),
+    then no cards from that pod other than this restricted card may be included in a deck.</p>

--- a/tests/Services/RestrictionsCheckerTest.php
+++ b/tests/Services/RestrictionsCheckerTest.php
@@ -47,7 +47,15 @@ class RestrictionsCheckerTest extends TestCase
                         'title' => 'P2',
                         'restricted' => '01005',
                         'cards' => ['01003', '01004']
-                    ]
+                    ],
+                    [
+                        'title' => 'P3',
+                        'cards' => ['01006', '01007']
+                    ],
+                    [
+                        'title' => 'P4',
+                        'cards' => ['01008', '01009']
+                    ],
                 ]
             ],
             'melee' => [
@@ -62,15 +70,23 @@ class RestrictionsCheckerTest extends TestCase
                 ],
                 'restricted_pods' => [
                     [
-                        'title' => 'P1',
+                        'title' => 'MP1',
                         'restricted' => '01000',
                         'cards' => ['01001', '01002']
                     ],
                     [
-                        'title' => 'P2',
+                        'title' => 'MP2',
                         'restricted' => '01005',
                         'cards' => ['01003', '01004']
-                    ]
+                    ],
+                    [
+                        'title' => 'MP3',
+                        'cards' => ['01006', '01007']
+                    ],
+                    [
+                        'title' => 'MP4',
+                        'cards' => ['01008', '01009']
+                    ],
                 ]
             ],
         ];
@@ -90,6 +106,7 @@ class RestrictionsCheckerTest extends TestCase
             [['04001', '04002', '01000'], 'contains one restricted card'],
             [['01000', '01003', '01004'], 'contains one restricted card and cards from a different restricted-pod.'],
             [['01001', '01002'], 'contains cards in restricted-pod but not the restricted card itself.'],
+            [['01006', '01008'], 'contains cards in pods but only one from each pod max.'],
             [[], 'empty list']
         ];
     }
@@ -125,6 +142,7 @@ class RestrictionsCheckerTest extends TestCase
             [['04001', '04002', '01900'], 'contains banned card'],
             [['04001', '04002', '01000', '01005'], 'contains more than one restricted card'],
             [['01000', '01001'], 'contains restricted card and a card in its restricted-pod.'],
+            [['01006', '01007'], 'contains more than one card from a pod.'],
         ];
     }
 

--- a/translations/messages.de.yml
+++ b/translations/messages.de.yml
@@ -394,8 +394,10 @@ pag:
   cardscount: "{0} Keine Karten | {1} Eine Karte | ]1,Inf] %count% Karten"
 
 card:
-  podinfo_single: "%format% - Falls %restricted% Deine Eingeschränkte Karte ist, dann kannst Du %card% nicht in Dein Deck aufnehmen."
-  podinfo_multiple: '%format% - Falls %restricted% Deine Eingeschränkte Karte ist, dann kannst Du die folgenden Karten nicht in Dein Deck aufnehmen: %cards%.'
+  podinfo_single: '%format% - Wenn Dein Deck %card% enthält, dann kann es nicht %other_card% enthalten.'
+  podinfo_multiple: '%format% - Wenn Dein Deck %card% enthält, dann kann es keine der folgenden Karten enthalten: %other_cards%.'
+  restricted_podinfo_single: "%format% - Falls %restricted% Deine Eingeschränkte Karte ist, dann kannst Du %card% nicht in Dein Deck aufnehmen."
+  restricted_podinfo_multiple: '%format% - Falls %restricted% Deine Eingeschränkte Karte ist, dann kannst Du die folgenden Karten nicht in Dein Deck aufnehmen: %cards%.'
   rl-joust:
     title: "Diese Karte ist auf der Liste Eingeschränkter Karten für Tjost."
   rl-melee:

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -395,8 +395,10 @@ pag:
   cardscount: "{0} There is no cards | {1} One card | ]1,Inf] %count% cards"
 
 card:
-  podinfo_single: '%format% - If %restricted% is your chosen restricted card, you cannot include %card% in your deck.'
-  podinfo_multiple: '%format% - If %restricted% is your chosen restricted card, you cannot include the following cards in your deck: %cards%.'
+  podinfo_single: '%format% - If you deck includes %card% then it cannot include %other_card%.'
+  podinfo_multiple: '%format% - If you deck includes %card% then it cannot include any of the following cards: %other_cards%.'
+  restricted_podinfo_single: '%format% - If %restricted% is your chosen restricted card, you cannot include %card% in your deck.'
+  restricted_podinfo_multiple: '%format% - If %restricted% is your chosen restricted card, you cannot include the following cards in your deck: %cards%.'
   rl-joust:
     title: "This card is on the Joust Restricted List."
   rl-melee:

--- a/translations/messages.es.yml
+++ b/translations/messages.es.yml
@@ -393,8 +393,10 @@ pag:
   cardscount: "{0} No hay cartas | {1} Una carta | ]1,Inf] %count% cartas"
 
 card:
-  podinfo_single: '%format% - Si %restricted% es tu carta restringida elegida, no puedes incluir %card% en tu mazo.'
-  podinfo_multiple: '%format% - Si %restricted% es tu carta restringida elegida, no puedes incluir las siguientes cartas en tu mazo: %cards%.'
+  podinfo_single: '%format% - Si tu mazo incluye %card%, entonces no puede incluir %other_card%.'
+  podinfo_multiple: '%format% - Si tu mazo incluye %card%, entonces no puede incluir ninguna de las siguientes cartas: %other_cards%.'
+  restricted_podinfo_single: '%format% - Si %restricted% es tu carta restringida elegida, no puedes incluir %card% en tu mazo.'
+  restricted_podinfo_multiple: '%format% - Si %restricted% es tu carta restringida elegida, no puedes incluir las siguientes cartas en tu mazo: %cards%.'
   rl-joust:
     title: "Su carta está en la la Lista Restringida Justa."
   rl-melee:


### PR DESCRIPTION
refs https://github.com/throneteki/throneteki-json-data/issues/95

some examples from the deck builder with hypothetical pods:

P9 = Great Hall and Aloof and Apart

![Selection_130](https://user-images.githubusercontent.com/1410427/103251502-bab96400-492d-11eb-9ac1-d197444f7604.png)

![Selection_129](https://user-images.githubusercontent.com/1410427/103251510-c60c8f80-492d-11eb-97b0-9bd5cc68a3a0.png)


P10 = Box Stannis, Fury, and Lightbringer

![Selection_133](https://user-images.githubusercontent.com/1410427/103251526-df154080-492d-11eb-9994-a4df83835c5a.png)
![Selection_134](https://user-images.githubusercontent.com/1410427/103251530-e1779a80-492d-11eb-8ca7-8b2e153b9fc2.png)


