### PR TITLE
Implements "no traits" cards filtering option

### DIFF
--- a/assets/js/app.smart_filter.js
+++ b/assets/js/app.smart_filter.js
@@ -96,19 +96,37 @@
     }
     function add_string_sf(key, operator, values)
     {
-        for(var j = 0; j < values.length; j++) {
-            values[j] = new RegExp(values[j], 'i');
+        var regExps = [];
+        var i, n
+        var $zeroTraitsSearch = (('traits' === key) && (1 === values.length) && ('-' === values[0].trim()));
+
+        for(i = 0, n = values.length; i < n; i++) {
+            regExps[i] = new RegExp(values[i], 'i');
         }
+
         switch(operator) {
             case ":":
-                SmartFilterQuery[key] = {
-                    '$in': values
-                };
+                if ($zeroTraitsSearch) {
+                    SmartFilterQuery[key] = {
+                        '$eq': ''
+                    };
+                } else {
+                    SmartFilterQuery[key] = {
+                        '$in': regExps
+                    };
+                }
+
                 break;
             case "!":
-                SmartFilterQuery[key] = {
-                    '$nin': values
-                };
+                if ($zeroTraitsSearch) {
+                    SmartFilterQuery[key] = {
+                        '$ne': ''
+                    };
+                } else {
+                    SmartFilterQuery[key] = {
+                        '$nin': regExps
+                    };
+                }
                 break;
         }
     }

--- a/src/Services/CardsData.php
+++ b/src/Services/CardsData.php
@@ -404,30 +404,40 @@ class CardsData
                             foreach ($condition as $arg) {
                                 switch ($operator) {
                                     case ':':
-                                        $or[] = "((c.traits = ?$i) or (c.traits like ?"
-                                            . ($i + 1)
-                                            . ") or (c.traits like ?"
-                                            . ($i + 2)
-                                            . ") or (c.traits like ?"
-                                            . ($i + 3)
-                                            . "))";
-                                        $qb->setParameter($i++, "$arg.");
-                                        $qb->setParameter($i++, "$arg. %");
-                                        $qb->setParameter($i++, "%. $arg.");
-                                        $qb->setParameter($i++, "%. $arg. %");
+                                        if ('-' === $arg) {
+                                            $or[] = "(c.traits = ?$i)";
+                                            $qb->setParameter($i++, '');
+                                        } else {
+                                            $or[] = "((c.traits = ?$i) or (c.traits like ?"
+                                                . ($i + 1)
+                                                . ") or (c.traits like ?"
+                                                . ($i + 2)
+                                                . ") or (c.traits like ?"
+                                                . ($i + 3)
+                                                . "))";
+                                            $qb->setParameter($i++, "$arg.");
+                                            $qb->setParameter($i++, "$arg. %");
+                                            $qb->setParameter($i++, "%. $arg.");
+                                            $qb->setParameter($i++, "%. $arg. %");
+                                        }
                                         break;
                                     case '!':
-                                        $or[] = "(c.traits is null or ((c.traits != ?$i) and (c.traits not like ?"
-                                            . ($i + 1)
-                                            . ") and (c.traits not like ?"
-                                            . ($i + 2)
-                                            . ") and (c.traits not like ?"
-                                            . ($i + 3)
-                                            . ")))";
-                                        $qb->setParameter($i++, "$arg.");
-                                        $qb->setParameter($i++, "$arg. %");
-                                        $qb->setParameter($i++, "%. $arg.");
-                                        $qb->setParameter($i++, "%. $arg. %");
+                                        if ('-' === $arg) {
+                                            $or[] = "(c.traits <> ?$i)";
+                                            $qb->setParameter($i++, '');
+                                        } else {
+                                            $or[] = "(c.traits is null or ((c.traits != ?$i) and (c.traits not like ?"
+                                                . ($i + 1)
+                                                . ") and (c.traits not like ?"
+                                                . ($i + 2)
+                                                . ") and (c.traits not like ?"
+                                                . ($i + 3)
+                                                . ")))";
+                                            $qb->setParameter($i++, "$arg.");
+                                            $qb->setParameter($i++, "$arg. %");
+                                            $qb->setParameter($i++, "%. $arg.");
+                                            $qb->setParameter($i++, "%. $arg. %");
+                                        }
                                         break;
                                 }
                             }

--- a/templates/Search/searchform.html.twig
+++ b/templates/Search/searchform.html.twig
@@ -157,6 +157,8 @@
                                     <div>
                                         <select class="form-control" name="k" id="k">
                                             <option value="">{{ 'search.any' | trans }}</option>
+                                            <option value="-">{{  'search.none' | trans }}</option>
+                                            <option disabled>&nbsp;</option>
                                             {% for trait in traits %}
                                                 <option value="{{ trait }}">{{ trait }}</option>
                                             {% endfor %}

--- a/translations/messages.de.yml
+++ b/translations/messages.de.yml
@@ -376,6 +376,7 @@ search:
   any: Beliebig
   yes: Ja
   no: Nein
+  none: keine
   only: Nur
   sort:
     name: Sortieren nach Name

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -376,6 +376,7 @@ search:
   any: any
   yes: Yes
   no: No
+  none: none
   only: Only
   sort:
     name: Sort by Name

--- a/translations/messages.es.yml
+++ b/translations/messages.es.yml
@@ -375,6 +375,7 @@ search:
   any: cualquiera
   yes: Sí
   no: No
+  none: ninguno
   only: Sólo
   sort:
     name: Ordenar por nombre


### PR DESCRIPTION
fixes #728 

filter syntax for "no traits" is `k:-`.

![deckbuilder-filter-traitless-character](https://user-images.githubusercontent.com/1410427/111555111-ee45a680-8744-11eb-9c43-03c141ed6647.png)
![searchform-traitless](https://user-images.githubusercontent.com/1410427/111555116-f0a80080-8744-11eb-9a62-8914e21b5d00.png)
![search-results-traitless-character](https://user-images.githubusercontent.com/1410427/111555123-f271c400-8744-11eb-91b9-8d00a6a82e67.png)
