### PR TITLE
Remove FAQ about limited duplicates

### DIFF
--- a/templates/Default/faq.en.html.twig
+++ b/templates/Default/faq.en.html.twig
@@ -633,24 +633,6 @@
         alone," and the check on "is attacking alone" is made at the time the event would be played.
     <p>
 
-    <h3 id="FAQ_8">Limited Cards in Setup</h3>
-
-    <p><i>If I play a limited card as a duplicate, does it count as my limited card for the round?</i></p>
-
-    <p>Yes. The limited keyword is checked during step 1 of the timing sequence detailed on
-        <a href="{{ path('rulesreference', { _fragment: 'Initiating_Abilities_Marshaling_Cards' }) }}" target="_blank">
-        page 10 of the RR</a>, which asks the question: "can the card be marshaled or played, or the ability initiated
-        at this time?" In order to play a duplicate, a player must make several verifications during this step: that the
-        card is unique, that he or she owns and controls a copy of that card in play, that there is no copy of that card
-        in his or her dead pile. If the card to be played as a duplicate is limited, the player must also verify that he
-        or she has not yet marshaled or played a limited card this round. If the player has not yet marshaled or played
-        a limited card this round, and proceeds to marshal the card, the card does count count as the player's limited
-        card for the round.</p>
-
-    <p class="mplain"><b>Related:</b> <a href="{{ path('cards_zoom', { card_code: "02064" }) }}" target="_blank">The Arbor</a>,
-        <a href="{{ path('cards_zoom', { card_code: "05017" }) }}" target="_blank">Golden Tooth</a>.</p>
-
-
     <h3 id="FAQ_21">Limited Card as Duplicate</h3>
     <p>
         <i>If I play a limited card as a duplicate, does it count as my limited card for the round?</i>


### PR DESCRIPTION
The rule about duplicates counting as your Limited card was changed in
FAQ v2.3 with the rule directly under the one being removed. While the
title references not allowing duplicated limited cards during setup,
none of the text references set up.

Since the two FAQs are contradictory, and the last ruling was that
duplicates do not count for Limited, remove the earlier FAQ.