### PR TITLE
tell search bots to ignore API and API-docs.

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,4 +2,4 @@
 # www.google.com/support/webmasters/bin/answer.py?hl=en&answer=156449
 
 User-agent: *
-Disallow:
+Disallow: /api/*


### PR DESCRIPTION
the /api page is fine, the rest should be ignored.