### PR TITLE
Affiliation Name after Icon using Print Stylesheet

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -533,6 +533,9 @@ article.review .review-comment {
 	    content: "(Stark)";
 	}
 
+    .icon.fg-baratheon::after {
+        content: "(Baratheon)";
+    }
 }
 
 /*************** DECK(LIST) COMPARE *****************/

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -497,6 +497,42 @@ article.review .review-comment {
     .col-print-10{width:83%; float:left;}
     .col-print-11{width:92%; float:left;}
     .col-print-12{width:100%; float:left;}
+	.icon::after {
+	    font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+	}
+
+	.icon.fg-tyrell::after {
+	    content: "(Tyrell)";
+	}
+
+	.icon.fg-targaryen::after {
+	    content: "(Targaryen)";
+	}
+
+	.icon.fg-neutral::after {
+	    content: "(Neutral)";
+	}
+
+	.icon.fg-greyjoy::after {
+	    content: "(Greyjoy)";
+	}
+
+	.icon.fg-lannister::after {
+	    content: "(Lannister)";
+	}
+
+	.icon.fg-thenightswatch::after {
+	    content: "(The Night's Watch)";
+	}
+
+	.icon.fg-martell::after {
+	    content: "(Martell)";
+	}
+
+	.icon.fg-stark::after {
+	    content: "(Stark)";
+	}
+
 }
 
 /*************** DECK(LIST) COMPARE *****************/


### PR DESCRIPTION
Adds affiliation text after the icon affiliation. This solves for color blindness as well as makes printed deck lists easier to use for those who store their cards by type and affiliation rather than Expansion/Pack but want to preserve the ordering from ThronesDB. No changes to template engine. It’s done through pure css using an ::after for each affiliation. Addresses #868 for the print style sheet.