### PR TITLE
Add CSS Columns to decklist while Printing

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -536,6 +536,9 @@ article.review .review-comment {
     .icon.fg-baratheon::after {
         content: "(Baratheon)";
     }
+	#deck-content .deck-content {
+		column-count:2;
+	}
 }
 
 /*************** DECK(LIST) COMPARE *****************/


### PR DESCRIPTION
Makes greater use of physical media whitespace by reflowing content across two columns that expand to the full-width of the page, allowing more cards within a decklist to fit on single sheet of paper.