### PR TITLE
Better errata handling

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -12,6 +12,14 @@ body {
     border-bottom: none;
 }
 
+.card-errata-long {
+    font-weight: bold;
+}
+
+.card-errata-short {
+    font-style: italic;
+}
+
 .card-name {
     font-family: 'Julius Sans One', sans-serif;
     font-weight: 700;

--- a/assets/js/app.card_modal.js
+++ b/assets/js/app.card_modal.js
@@ -29,8 +29,13 @@
         var info = '<div class="card-faction">' + app.format.faction(card) + '</div>'
           + '<div class="card-info">' + app.format.info(card) + '</div>'
           + '<div class="card-traits">' + app.format.traits(card) + '</div>'
-          + '<div class="card-text border-' + card.faction_code + '">' + app.format.text(card) + '</div>'
-          + '<div class="card-pack">' + app.format.pack(card) + '</div>';
+          + '<div class="card-text border-' + card.faction_code + '">' + app.format.text(card) + '</div>';
+
+        if (card.errataed) {
+            info += '<div class="card-errata-short">' +  Translator.trans('card.info.errataed_short')  + '</div>';
+        }
+
+        info += '<div class="card-pack">' + app.format.pack(card) + '</div>';
 
         if (card.work_in_progress) {
             info = '<div class="alert alert-danger">' +  Translator.trans('card.info.workInProgress')  + '</div>' + info;

--- a/assets/js/app.tip.js
+++ b/assets/js/app.tip.js
@@ -20,8 +20,14 @@
               + '<div class="card-faction">' + app.format.faction(card) + '</div>'
               + '<div class="card-info">' + app.format.info(card) + '</div>'
               + '<div class="card-traits">' + app.format.traits(card) + '</div>'
-              + '<div class="card-text border-' + card.faction_code + '">' + app.format.text(card) + '</div>'
-              + '<div class="card-pack">' + app.format.pack(card) + '</div>';
+              + '<div class="card-text border-' + card.faction_code + '">' + app.format.text(card) + '</div>';
+
+
+            if (card.errataed) {
+                info += '<div class="card-errata-short">' +  Translator.trans('card.info.errataed_short')  + '</div>';
+            }
+
+            info += '<div class="card-pack">' + app.format.pack(card) + '</div>';
             content = image + info;
         } else {
             content = card.image_url ? '<img src="' + card.image_url + '">' : "";

--- a/migrations/Version20240214040710.php
+++ b/migrations/Version20240214040710.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds errataed column to card table
+ */
+final class Version20240214040710 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Adds errataed column to card table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE card ADD errataed TINYINT(1) NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE card DROP errataed');
+    }
+}

--- a/src/Command/ImportStdCommand.php
+++ b/src/Command/ImportStdCommand.php
@@ -230,10 +230,7 @@ class ImportStdCommand extends Command
                     $data['position'] = $position;
                     $data['quantity'] = $item['quantity'];
                     $data['text'] = $item['text'];
-                    // @todo Replace this stop-gap solution and import errata properly. [ST 2020/04/12]
-                    if (array_key_exists('errata', $item) && $item['errata']) {
-                        $data['text'] .= "\n<em>Errata'd.</em>";
-                    }
+                    $data['errataed'] = array_key_exists('errata', $item) && !empty($item['errata']);
                     if (array_key_exists('imageUrl', $item)) {
                         $data['image_url'] = $item['imageUrl'];
                     }
@@ -285,7 +282,8 @@ class ImportStdCommand extends Command
                             'flavor',
                             'is_loyal',
                             'is_unique',
-                            'is_multiple'
+                            'is_multiple',
+                            'errataed',
                         ],
                         [
                             'faction_code',

--- a/src/Entity/Card.php
+++ b/src/Entity/Card.php
@@ -659,18 +659,12 @@ class Card implements CardInterface
         return $this->octgnId;
     }
 
-    /**
-     * @inheritdoc
-     */
     public function setErrataed(bool $errataed): void
     {
         $this->errataed = $errataed;
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function isErrataed(): bool
+    public function getErrataed(): bool
     {
         return $this->errataed;
     }

--- a/src/Entity/Card.php
+++ b/src/Entity/Card.php
@@ -853,6 +853,7 @@ class Card implements CardInterface
             'is_unique',
             'is_multiple',
             'octgn_id',
+            'errataed',
         ];
 
         $optionalFields = [

--- a/src/Entity/Card.php
+++ b/src/Entity/Card.php
@@ -215,6 +215,13 @@ class Card implements CardInterface
     protected $imageUrl;
 
     /**
+     * @var bool
+     *
+     * @ORM\Column(name="errataed", type="boolean", nullable=false)
+     */
+    protected bool $errataed;
+
+    /**
      * @var Collection
      *
      * @ORM\OneToMany(targetEntity="App\Entity\Review", mappedBy="card")
@@ -263,6 +270,7 @@ class Card implements CardInterface
         $this->isIntrigue = false;
         $this->isPower = false;
         $this->isMultiple = false;
+        $this->errataed = false;
 
         $this->reviews = new ArrayCollection();
     }
@@ -649,6 +657,22 @@ class Card implements CardInterface
     public function getOctgnId()
     {
         return $this->octgnId;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setErrataed(bool $errataed): void
+    {
+        $this->errataed = $errataed;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isErrataed(): bool
+    {
+        return $this->errataed;
     }
 
     /**

--- a/src/Entity/CardInterface.php
+++ b/src/Entity/CardInterface.php
@@ -260,7 +260,7 @@ interface CardInterface extends Serializable
     /**
      * @return bool
      */
-    public function isErrataed(): bool;
+    public function getErrataed(): bool;
 
     /**
      * @param ReviewInterface $review

--- a/src/Entity/CardInterface.php
+++ b/src/Entity/CardInterface.php
@@ -253,6 +253,16 @@ interface CardInterface extends Serializable
     public function getOctgnId();
 
     /**
+     * @param bool $octgnId
+     */
+    public function setErrataed(bool $errataed): void;
+
+    /**
+     * @return bool
+     */
+    public function isErrataed(): bool;
+
+    /**
      * @param ReviewInterface $review
      */
     public function addReview(ReviewInterface $review);

--- a/templates/Search/card-errata-long.html.twig
+++ b/templates/Search/card-errata-long.html.twig
@@ -1,0 +1,3 @@
+<p class="card-errata-long">
+    {{ "card.info.errataed_long" | trans({"%url%":  path("faq", {"_fragment": "Card_Errata"})}) | raw }}
+</p>

--- a/templates/Search/card-errata-short.html.twig
+++ b/templates/Search/card-errata-short.html.twig
@@ -1,0 +1,3 @@
+<div class="card-errata-short">
+    {{ "card.info.errataed_short" | trans }}
+</div>

--- a/templates/Search/display-card.html.twig
+++ b/templates/Search/display-card.html.twig
@@ -29,9 +29,15 @@
                                     {% include 'Search/card-pack.html.twig' %}
                                 </div>
                             </div>
+                            {% if card.errataed %}
+                                <p>
+                                    <strong>{{ "card.info.errataed_long" | trans({"%url%":  path("faq", {"_fragment": "Card_Errata"})}) | raw }}</strong>
+                                </p>
+                            {% endif %}
                             <p>Link:
                                 <a href="{{ path('decklists_list',{type:'find',_locale:app.request.locale,'cards[]':card.code}) }}">Decklists</a>
                             </p>
+
                         </div>
                     </div>
                     <div class="col-sm-5" style="margin-bottom:2em">

--- a/templates/Search/display-card.html.twig
+++ b/templates/Search/display-card.html.twig
@@ -24,15 +24,16 @@
                                     {% include 'Search/card-faction.html.twig' %}
                                     {% include 'Search/card-info.html.twig' %}
                                     {% include 'Search/card-text.html.twig' %}
+                                    {% if card.errataed %}
+                                        {%  include 'Search/card-errata-short.html.twig' %}
+                                    {% endif %}
                                     {% include 'Search/card-flavor.html.twig' %}
                                     {% include 'Search/card-illustrator.html.twig' %}
                                     {% include 'Search/card-pack.html.twig' %}
                                 </div>
                             </div>
                             {% if card.errataed %}
-                                <p>
-                                    <strong>{{ "card.info.errataed_long" | trans({"%url%":  path("faq", {"_fragment": "Card_Errata"})}) | raw }}</strong>
-                                </p>
+                                {%  include 'Search/card-errata-long.html.twig' %}
                             {% endif %}
                             <p>Link:
                                 <a href="{{ path('decklists_list',{type:'find',_locale:app.request.locale,'cards[]':card.code}) }}">Decklists</a>

--- a/templates/Search/display-spoiler.html.twig
+++ b/templates/Search/display-spoiler.html.twig
@@ -19,6 +19,9 @@
                             {% include 'Search/card-faction.html.twig' %}
                             {% include 'Search/card-info.html.twig' %}
                             {% include 'Search/card-text.html.twig' %}
+                            {% if card.errataed %}
+                                {% include 'Search/card-errata-short.html.twig' %}
+                            {% endif %}
                             {% include 'Search/card-flavor.html.twig' %}
                             {% include 'Search/card-illustrator.html.twig' %}
                             {% include 'Search/card-pack.html.twig' %}

--- a/translations/messages.de.yml
+++ b/translations/messages.de.yml
@@ -475,6 +475,8 @@ card:
     plotlimit: Strategiestapel-Limit
     quantity: Anzahl
     illustrator: Illustrator/in
+    errataed_short: Druckfehler.
+    errataed_long: Der Originaldruck dieser Karte ist fehlerhaft. Weitere Informationen finden Sie in den <a href='%url%'>FAQ</a>.
     short:
       costgold: K.
       strini: S.

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -476,6 +476,8 @@ card:
     plotlimit: Plot deck limit
     quantity: Quantity
     illustrator: Illustrator
+    errataed_short: Errata'ed.
+    errataed_long: This card has been errata'ed from its original print. Please see the <a href='%url%'>FAQ</a> for details.
     short:
       costgold: C.
       strini: S.

--- a/translations/messages.es.yml
+++ b/translations/messages.es.yml
@@ -474,6 +474,8 @@ card:
     plotlimit: Límite por mazo
     quantity: Cantidad
     illustrator: Ilustrador
+    errataed_short: Fe de erratas.
+    errataed_long: Esta tarjeta ha sido erratada de su impresión original. Consulte las <a href='%url%'>Preguntas frecuentes</a> para obtener más detalles.
     short:
       costgold: C.
       strini: Fu.


### PR DESCRIPTION
fixes https://github.com/ThronesDB/thronesdb/issues/935

Short-text and linked long-text variants of errata info on default card details page. 

![image](https://github.com/ThronesDB/thronesdb/assets/1410427/476a7ad6-e7c1-415f-ae05-6834b49a024e)

short-text variant in spoiler-mode search results

![image](https://github.com/ThronesDB/thronesdb/assets/1410427/7cd23f39-dd65-45e0-958a-40f664ab85e7)


short-text variant in card modal and in card tooltip:

![image](https://github.com/ThronesDB/thronesdb/assets/1410427/90e39465-9320-4999-b3b8-857a37c63f82)

![image](https://github.com/ThronesDB/thronesdb/assets/1410427/88c1bbfc-76c8-4874-a4ab-0bfc93bee3f0)

