### PR TITLE
correct frontend deck validation function for Uniting the Realm (WK) agenda.

### DIFF
--- a/assets/js/app.deck.js
+++ b/assets/js/app.deck.js
@@ -1252,7 +1252,7 @@
 
         var validate_uniting_the_realm = function() {
             var factions = {};
-            return deck.get_cards().every(function(card) {
+            return deck.get_draw_deck().every(function(card) {
                 var faction = card.faction_code;
                 var name = card.name;
                 if ('neutral' === faction) {
@@ -1466,7 +1466,7 @@
             case '20051':
                 return card.type_code === 'character' && card.traits.indexOf(Translator.trans('card.traits.fool')) !== -1;
             case '25120':
-                return card.faction_code === 'neutral' || ['character', 'attachment', 'location'].includes(card.type_code);
+                return card.faction_code === 'neutral' || ['character', 'attachment', 'location'].includes(card.type_code)
         }
     };
 })(app.deck = {}, jQuery);


### PR DESCRIPTION
Only process the draw deck here, otherwise loyal agendas of the main faction that are included in the plot deck cause deck validation to fail.

fixes #951 