### PR TITLE
fixes regression in deck validation

### DIFF
--- a/src/Services/DeckValidationHelper.php
+++ b/src/Services/DeckValidationHelper.php
@@ -59,6 +59,8 @@ class DeckValidationHelper
                 case '13118': // Valyrian Steel (BtRK)
                 case '17152': // Valyrian Steel (R)
                 case '16028': // Dark Wings, Dark Words
+                    $expectedMinCardCount = 75;
+                    break;
                 case '16030': // The Long Voyage
                     $expectedMinCardCount = 100;
                     break;


### PR DESCRIPTION
commit  b70ca0661f9d09e4d66b5ccd4df982454feb2f30 was bugged, resulting in false negatives when validating deck size for both Valyrian Steel's and DWDW server-side.