### PR TITLE
adds support for new Tower of Joy (ToJ) draft set

### DIFF
--- a/assets/js/app.deck.js
+++ b/assets/js/app.deck.js
@@ -471,17 +471,6 @@
      * @memberOf deck
      * @returns boolean
      */
-    deck.is_the_kings_voice = function is_the_kings_voice()
-    {
-        return !(_.isUndefined(_.find(deck.get_agendas(), function (card) {
-            return card.code === '00030';
-        })));
-    };
-
-    /**
-     * @memberOf deck
-     * @returns boolean
-     */
     deck.is_rains_of_castamere = function is_rains_of_castamere() {
         return !(_.isUndefined(_.find(deck.get_agendas(), function(card) {
             return card.code === '05045';
@@ -918,7 +907,7 @@
             // card-specific rules
             switch(card.type_code) {
                 case 'agenda':
-                    if (deck.is_the_kings_voice()) {
+                    if (deck.is_unsupported_agenda(card.type_code)) {
                         break;
                     }
 
@@ -1024,13 +1013,35 @@
     {
         var warnings = [];
         var agendas = deck.get_agendas();
-        var unsupportedAgendas = ['00030'];
-        agendas.forEach(function (agenda) {
-            if (unsupportedAgendas.includes(agenda.code)) {
+        agendas.every(function (agenda) {
+            if (deck.is_unsupported_agenda(agenda.code)) {
                 warnings.push(Translator.trans('decks.warnings.unsupported_agenda', {agenda: agenda.name}));
+                return false;
             }
+            return true;
         });
         return warnings;
+    };
+
+    deck.get_unsupported_agendas = function get_unsupported_agendas()
+    {
+        return [
+            '00030', // The King's Voice (VHotK)
+            '00357', // Sealing the Pact (ToJ)
+            '00358', // Three Heads of the Dragon (ToJ)
+            '00359', // Shadowbinders of Assai (ToJ)
+            '00360', // The Iron Bank of Braavos (ToJ)
+            '00361', // Join Forces (ToJ)
+            '00362', // Desperate Hope (ToJ)
+            '00363', // Crossroads Inkeeper (ToJ)
+        ];
+    };
+
+    deck.is_unsupported_agenda = function is_unsupported_agenda()
+    {
+        return !(_.isUndefined(_.find(deck.get_agendas(), function (card) {
+               return deck.get_unsupported_agendas().includes(card.code);
+        })));
     };
 
     /**

--- a/assets/js/ui.deckedit.js
+++ b/assets/js/ui.deckedit.js
@@ -124,7 +124,7 @@
             // one of the variant/"special" products like Valyrian Draft Set (VDS).
             if(! record.available
               || Date.parse(record.available) > Date.now()
-              || ['VDS', 'VKm', 'VHotK'].includes(record.code)
+              || ['VDS', 'VKm', 'VHotK', 'ToJ'].includes(record.code)
             ) {
                 checked = false;
             }

--- a/src/Controller/BuilderController.php
+++ b/src/Controller/BuilderController.php
@@ -57,6 +57,13 @@ class BuilderController extends AbstractController
         '00003', // Treaty (VDS)
         '00004', // Uniting the Seven Kingdoms (VDS)
         "00030", // The King's Voice (VHotK)
+        "00357", // Sealing the Pact (ToJ)
+        "00358", // Three Heads of the Dragon (ToJ)
+        "00359", // Shadowbinders of Assai (ToJ)
+        "00360", // The Iron Bank of Braavos (ToJ)
+        "00361", // Join Forces (ToJ)
+        "00362", // Desperate Hope (ToJ)
+        "00363", // Crossroads Inkeeper (ToJ)
     ];
 
     /**


### PR DESCRIPTION
- make Agendas from this set unavailable by default for new decks in the agenda picker form.
- in the deck builder, deselect the new draft set by default
- indicate deck validation rules as _not supported_ in the deck builder for ToJ agendas


![image](https://github.com/user-attachments/assets/9dcc014a-1b41-417e-b106-1ed1f79e47ec)

![image](https://github.com/user-attachments/assets/74432528-e958-417b-9f32-2c0b63629cf0)

![image](https://github.com/user-attachments/assets/0dabb71e-bba5-4e80-9938-c7164e47c90c)


refs https://github.com/throneteki-playtesting/throneteki-json-data/pull/33